### PR TITLE
NAS-109649 / 21.04 / add ability to reserve disks based off detected zpool(s)

### DIFF
--- a/fenced/logging.py
+++ b/fenced/logging.py
@@ -16,6 +16,8 @@ def ensure_logdir_exists():
 
 
 def setup_logging(foreground):
+    # ignore annoying ws4py close debug messages
+    logging.getLogger('ws4py').setLevel(logging.WARN)
 
     ensure_logdir_exists()
 


### PR DESCRIPTION
- use middlewared client to generate a list of disks detected on the system
- add `--use-zpools`, `-uz` arguments to provide the ability to reserve the disks in use by the detected zpools