### PR TITLE
NAS-116071 / 22.02.4 / use /etc/machine-id instead of /etc/hostid

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fenced (0.3) experimental; urgency=medium
+
+  [ Caleb St. John ]
+  * use /etc/machine-id instead of /etc/hostid
+
+ -- Caleb <yocalebo@gmail.com>  Thu, 04 Aug 2022 08:30:00 -0500
+
 fenced (0.2) experimental; urgency=medium
 
   [ Caleb St. John ]

--- a/fenced/fence.py
+++ b/fenced/fence.py
@@ -11,7 +11,7 @@ from middlewared.client import Client
 
 logger = logging.getLogger(__name__)
 
-ID_FILE = '/etc/hostid'
+ID_FILE = '/etc/machine-id'
 
 
 class ExitCode(enum.IntEnum):
@@ -35,8 +35,8 @@ class Fence(object):
 
     def get_hostid(self):
         try:
-            with open(ID_FILE, 'rb') as f:
-                return int(f.read(4).hex(), 16)
+            with open(ID_FILE) as f:
+                return int(f.read(8), 16)
         except Exception:
             logger.error('failed to generate unique id', exc_info=True)
             sys.exit(ExitCode.UNKNOWN.value)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='fenced',
-    version='0.0.2',
+    version='0.0.3',
     description='TrueNAS SCALE Fencing Daemon',
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
I can't depend on /etc/hostid being unique between controllers on an HA system. At least, not when SCALE is installed as a VM on a bhyve host. The /etc/hostid's are the same between the VMs which breaks this program at a fundamental level.