### PR TITLE
NAS-127630 / 24.04-RC.1 / handle edge-case error on preemption (by yocalebo)

### DIFF
--- a/fenced/disks.py
+++ b/fenced/disks.py
@@ -148,11 +148,7 @@ class Disk(object):
                 try:
                     self.disk.preempt_key(reservation['reservation'], newkey)
                 except SCSIErrorException as e:
-                    if all((
-                        e.args,
-                        isinstance(e.args[0], SCSI_OPCODES),
-                        e.args[0] == SCSI_OPCODES.RESERVATION_CONFLICT
-                    )):
+                    if e.args and e.args[0] == SCSI_OPCODES.RESERVATION_CONFLICT:
                         # the logic by which we check if the reservation is "owned"
                         # by this host is custom logic that was written by us and is
                         # flawed. The spec for handling pr keys defines a command


### PR DESCRIPTION
The logic by which we check if the reservation is "owned"
by this host is custom logic that was written by us and is
flawed. The spec for handling pr keys defines a command
that can be used to determine if this host is the current
reservation holder. Since we don't have this, we check
for reservation conflict and try to "update" the key since
getting a reservation conflict when trying to preempt the
current key typically means this host is the current owner

Original PR: https://github.com/truenas/py-fenced/pull/41
Jira URL: https://ixsystems.atlassian.net/browse/NAS-127630