### PR TITLE
NAS-131395 / 24.10.0 / fix subtle regression in fenced (by yocalebo)

### DIFF
--- a/fenced/utils.py
+++ b/fenced/utils.py
@@ -54,13 +54,12 @@ def load_disks_lsblk(ignore):
     ]
     disks = {}
     try:
-        disks = {
-            i["name"]: i["serial"]
-            for i in json.loads(
-                subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode()
-            )["blockdevices"]
-            if not i["name"].startswith(ignore[0]) or ignore[1].match(i["name"])
-        }
+        stdout = subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode()
+        for i in json.loads(stdout)["blockdevices"]:
+            if i["name"].startswith(ignore[0]) or ignore[1].match(i["name"]):
+                continue
+            else:
+                disks[i["name"]] = i["serial"]
     except Exception:
         logger.error("Unhandled exception", exc_info=True)
 


### PR DESCRIPTION
The most recent changes here added a 2nd attempt at enumerating disks to work-around a particular situation we're seeing for a particular shelf in the field. The problem, is that the skip logic was inverted so the 2nd attempt actually produced 0 disks.

Because of this issue, the particular problem it set out to solve was rendered useless because the 2nd attempt should be producing MORE disks than the 1st attempt (again problem a particular shelf). This fixes that regression by removing the dict comprehension and doing a good ole fashioned for loop.

Original PR: https://github.com/truenas/py-fenced/pull/51
Jira URL: https://ixsystems.atlassian.net/browse/NAS-131395