### PR TITLE
NAS-131419 / 25.04 / greatly simplify disk enumeration in fenced

### DIFF
--- a/fenced/main.py
+++ b/fenced/main.py
@@ -86,6 +86,18 @@ def set_resource_limits():
     limits = (4096, 4096)  # soft and hard limits respectively
     resource.setrlimit(resource.RLIMIT_NOFILE, limits)
 
+def parse_ed(value) -> tuple[str] | tuple:
+    parsed = list()
+    try:
+        for i in value.split():
+            for j in i.split(','):
+                if (j := j.strip()):
+                    parsed.append(j)
+    except Exception:
+        logger.error('Unexpected failure parsing exclude disks', exc_info=True)
+
+    return tuple(parsed)
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -112,7 +124,8 @@ def main():
     )
     parser.add_argument(
         '--exclude-disks', '-ed',
-        default=[],
+        default='',
+        type=parse_ed,
         help='List of disks to be excluded from SCSI reservations.'
              ' (THIS CAN CAUSE PROBLEMS IF YOU DONT KNOW WHAT YOURE DOING)',
     )

--- a/fenced/main.py
+++ b/fenced/main.py
@@ -87,6 +87,9 @@ def set_resource_limits():
     resource.setrlimit(resource.RLIMIT_NOFILE, limits)
 
 def parse_ed(value) -> tuple[str] | tuple:
+    """This method is used to parse the disks to be excluded
+    from fenced. This is given to us by the caller exclusively.
+    """
     parsed = list()
     try:
         for i in value.split():

--- a/fenced/utils.py
+++ b/fenced/utils.py
@@ -1,169 +1,61 @@
-import json
-import logging
-import re
-import subprocess
+from dataclasses import dataclass
+from logging import getLogger
+from os import DirEntry, scandir
+from re import compile as re_compile, Pattern
 
-from truenas_api_client import Client
-
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
-def load_disks_middleware_no_zpools(c, ignore):
-    # grab all detected disks on the system
-    disks = {}
-    try:
-        disks = {
-            k: v
-            for k, v in c.call("device.get_disks", False, True).items()
-            if not k.startswith(ignore[0]) and not ignore[1].match(k)
-        }
-    except Exception:
-        logger.error("Unhandled exception", exc_info=True)
-
-    return disks
+@dataclass(slots=True, frozen=True, kw_only=True)
+class IgnoreObject:
+    prefixes: tuple[str] = ("sr", "md", "dm-", "loop", "zd", "pmem")
+    """A tuple of prefixes for known block devices that we should ignore"""
+    pattern: Pattern = re_compile(r"nvme[0-9]+c")
+    """An nvme controller device"""
+    user_excluded_disks: tuple[str] | tuple = tuple()
+    """The caller can provide disk(s) to be excluded
+        from fenced. (i.e. boot drives in the head-unit)"""
 
 
-def load_disks_middleware_use_zpools(c, ignore):
-    disks = {}
-    try:
-        for i in c.call("pool.query"):
-            for j in filter(
-                lambda x: x["type"] == "DISK",
-                c.call("pool.flatten_topology", i["topology"]),
-            ):
-                if (
-                    j["disk"] is not None
-                    and not j["disk"].startswith(ignore[0])
-                    and not ignore[1].match(j["disk"])
-                ):
-                    disks[j["disk"]] = {"zpool": i["name"], "guid": i["guid"]}
-    except Exception:
-        logger.error("Unhandled exception", exc_info=True)
-
-    return disks
-
-
-def load_disks_lsblk(ignore):
-    cmd = [
-        "/usr/bin/lsblk",
-        "-J",
-        "-ndo",
-        "NAME,SERIAL",
-        "-I",
-        "8,65,66,67,68,69,70,71,128,129,130,131,132,133,134,135,254,259",
-    ]
-    disks = {}
-    try:
-        stdout = subprocess.run(cmd, stdout=subprocess.PIPE).stdout.decode()
-        for i in json.loads(stdout)["blockdevices"]:
-            if i["name"].startswith(ignore[0]) or ignore[1].match(i["name"]):
-                continue
-            else:
-                disks[i["name"]] = i["serial"]
-    except Exception:
-        logger.error("Unhandled exception", exc_info=True)
-
-    return disks
-
-
-def disks_to_be_ignored(ed=None):
-    prefixes = {"sr", "md", "dm-", "loop", "zd", "pmem"}
-    if ed is not None:
-        exclude = {}
-        try:
-            if isinstance(ed, list):
-                # it's a list by default if fenced is called without exclude disk args
-                exclude = {i for i in ed}
-            elif isinstance(ed, str):
-                # it's a comma separated list if fenced is called with exclude disk args
-                exclude = {i for i in ed.split(",") if i}
-        except Exception:
-            logger.warning("Failed to format exclude disks params", exc_info=True)
-        else:
-            if exclude:
-                prefixes.update(exclude)
-
-    return (tuple(prefixes), re.compile(r"nvme[0-9]+c"))
-
-
-def load_disks_impl(exclude_disks=None, use_zpools=False):
-    """
-    The name of the game for the various functions are ultimate fault tolerance.
-    Since fenced is paramount for preventing zpool corruption, we do everything we
-    can to prevent unexpected failures and always return disks.
-    """
-    disks_to_ignore = disks_to_be_ignored(ed=exclude_disks)
-    first_attempt_disks = {}
-    try:
-        with Client() as c:
-            if use_zpools:
-                first_attempt_disks = load_disks_middleware_use_zpools(
-                    c, disks_to_ignore
-                )
-
-            if not first_attempt_disks:
-                # load_disks_middleware_use_zpools can return nothing for reasons that aren't
-                # fully understood...it's imperative that we reserve disks since it, ultimately,
-                # prevents zpool corruption
-                first_attempt_disks = load_disks_middleware_no_zpools(
-                    c, disks_to_ignore
-                )
-    except Exception:
-        logger.error("Unhandled exception enumerating middleware client", exc_info=True)
-
-    # we've discovered that the ES24F, when fully populated with SAS SSD
-    # SEAGATE XS7680SE70084 0002, has a race condition where-by these disks
-    # haven't been cached in udevd's database during a failover event.
-    # This is particularly painful for the following scenario:
-    #   Have head-unit populated with disks, have ES24F fully populated. Failover
-    #   is triggered and fenced enumerates ONLY the disks in the head-unit. Since
-    #   we enumerated _SOME_ disks, we assume everything is fine and continue on
-    #   by design. However, when we go to import the zpool on the other controller
-    #   the import fails because the drives in the shelf were not enumerated thereby
-    #   preventing persistent reservations from being updated which ultimately ends
-    #   up with the zpool(s) failing to be imported. This is a production outage
-    #   scenario that requires administrative intervention which is painful.
-    #
-    # To combat this scenario, we will enumerate disks using middleware and then
-    # enumerate disks using a different method. We will take the larger of the
-    # enumerated disk objects. This was tested in the field on a customer system.
-    second_attempt_disks = load_disks_lsblk(disks_to_ignore)
-    if not first_attempt_disks:
-        if not second_attempt_disks:
-            # yikes....this is bad first and second attempt failed...
-            # just try 1 last time to return something
-            logger.warning(
-                "Two attempts enumerating disks failed. Trying one last time."
-            )
-            return load_disks_lsblk(disks_to_be_ignored)
-        else:
-            logger.warning(
-                "First attempt enumerating disks failed but second attempt succeeded."
-            )
-            return second_attempt_disks
-
-    len_first, len_second = len(first_attempt_disks), len(second_attempt_disks)
-    if len_first > len_second:
-        logger.warning(
-            "First attempt enumerated more disks (%r) than second attempt (%r).",
-            len_first,
-            len_second,
+def should_not_ignore(entry: DirEntry, ignore: IgnoreObject) -> bool:
+    """Returns true if the device should NOT be ignored, false otherwise"""
+    return all(
+        (
+            entry.is_symlink(),
+            not entry.name.startswith(ignore.prefixes),
+            not ignore.pattern.match(entry.name),
+            entry.name not in ignore.user_excluded_disks,
         )
-        return first_attempt_disks
-    elif len_second > len_first:
-        if use_zpools:
-            # use_zpools will place reservations on disks associated to zpool(s)
-            # which means the 2nd attempt could produce more drives since the
-            # zpool(s) might not being using all disks on the system. This is
-            # fine.
-            return first_attempt_disks
-        else:
-            logger.warning(
-                "Second attempt enumerated more disks (%r) than first attempt (%r)",
-                len_second,
-                len_first,
-            )
-            return second_attempt_disks
+    )
 
-    # first and second attempt are equal
-    return first_attempt_disks
+
+def load_disks_from_sys_block(ignore: IgnoreObject) -> dict[str, str]:
+    """By the time fenced is called, the OS is booted into multi-user
+    mode and has been for a bit. This means we should use sysfs to
+    enumerate the disks since using things like libudev, are fickle
+    and can have missing devices based on operations done in userspace.
+    (i.e. if someone causes a "rescan"). Sysfs does not suffer from
+    such scenarios. (Obviously, sysfs can be "updated" if the drive
+    catastrophically fails OR someone physically pulls it or someone
+    issues an hba reset, etc but there isn't a way to prevent such
+    situations in the first place)"""
+    disks = {}
+    try:
+        with scandir("/sys/block") as sdir:
+            for disk in filter(lambda x: should_not_ignore(x, ignore), sdir):
+                disks[disk.name] = disk.name
+    except Exception:
+        logger.error("Unhandled exception enumerating disks", exc_info=True)
+
+    return disks
+
+
+def load_disks_impl(ed: tuple[str] | tuple, use_zpools: bool = False) -> dict[str, str]:
+    """
+    Return disk(s) to have persistent reservations placed upon.
+        `ed`: user supplied disk(s) that will be excluded from having
+            persistent reservations placed upon them.
+        `use_zpools`: boolean is a NO_OP (for now) and is a placeholder
+            for generating a group of disks ONLY associated to a zpool.
+    """
+    return load_disks_from_sys_block(IgnoreObject(user_excluded_disks=ed))


### PR DESCRIPTION
After more investigation in the field, we've discovered that libudev is a fickle mistress when it comes to reliably enumerating disks on a system. The reason why is that libudev is a database cache of hardware that the kernel sees. However, it's very trivial to trigger "rescans" of such hardware which causes the udev cache to be torn down and recreated. To fix this, I remove the logic for enumerating disks via libudev.

While I'm here, I get rid of a bunch of unnecessary and duplicate logic that doesn't provide us any benefit. A list of what has changed is as follows:
1. remove libudev disk enumeration and depend on sysfs (/sys/block)
2. remove enumerating disks from middleware entirely. This means the reserve the disks in-use by a zpool "logic" was removed as well. This logic was a thought experiment we had years ago and it was only implemented for our single-node HA capable customers. (The entirety of why this was done was to prevent a customer from upgrading to HA and inserting the new controller, copying over the config and causing the zpool to be imported on both nodes at the same time ultimately ending up with complete loss of their zpool (we've seen this a few times before)). Instead, I just reserve all disk all the time so the possibility of the above scenario occurring is further limited by the fact all disks will be reserved and not only the disks being used by zpool(s)
3. simplify the parsing of the `-ed` flag (exclude disks). How it was being handled was complicated and unneeded.
4. simplify the `fenced/utils.py` file by adding logic enumerating disks via /sys/block ONLY. This allowed me to remove a bunch of cruft that was unneeded. I also did proper type annotations and documented everything so future developers have an idea of what is being done.

Finally, the changes added here in https://github.com/truenas/py-fenced/pull/51 are a work-around that doesn't actually fix the underlying issue. We're still seeing issues in the field but it does improve the situation. The changes here are more "proper" and remove the ugly work-arounds that hide insidious problems.

NOTE: tested these changes on an internal system as well as similar changes on a customer system in the field. No obvious regressions.