### PR TITLE
NAS-133370 / 25.04 / Improve ExitCode enum

### DIFF
--- a/fenced/main.py
+++ b/fenced/main.py
@@ -142,8 +142,9 @@ def main():
     setup_logging(args.foreground)
 
     if is_running():
-        logger.error('fenced already running.')
-        sys.exit(ExitCode.ALREADY_RUNNING.value)
+        rc, err = ExitCode.ALREADY_RUNNING.value
+        logger.error(err)
+        sys.exit(rc)
 
     set_resource_limits()
     fence = Fence(args.interval, args.exclude_disks, args.use_zpools)
@@ -169,16 +170,19 @@ def main():
         fence.loop(newkey)
     except PanicExit as e:
         if args.no_panic:
-            logger.warning('NO PANIC ERROR:', exc_info=True)
-            sys.exit(ExitCode.UNKNOWN.value)
+            rc, err = ExitCode.NO_PANIC.value
+            logger.warning(err, exc_info=True)
+            sys.exit(rc)
         else:
             panic(e)
     except ExcludeDisksError:
-        logger.critical('FATAL:', exc_info=True)
-        sys.exit(ExitCode.EXCLUDE_DISKS_ERROR.value)
+        rc, err = ExitCode.EXCLUDE_DISKS_ERROR.value
+        logger.critical(err, exc_info=True)
+        sys.exit(rc)
     except Exception:
-        logger.critical('Unhandled exception', exc_info=True)
-        sys.exit(ExitCode.UNKNOWN.value)
+        rc, err = ExitCode.UNKNOWN.value
+        logger.critical(err, exc_info=True)
+        sys.exit(rc)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This improves the `ExitCode` enum by adding human readable values. The reason why this needs to happen is because in certain (rare) situations, pool creation on an HA system will raise an exception like so
```
 Error: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 515, in run
    await self.future
  File "/usr/lib/python3/dist-packages/middlewared/job.py", line 560, in __run_body
    rv = await self.method(*args)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/service/crud_service.py", line 266, in nf
    rv = await func(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 48, in nf
    res = await f(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/schema/processor.py", line 174, in nf
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/middlewared/plugins/pool_/pool.py", line 579, in do_create
    raise CallError(err)
middlewared.service_exception.CallError: [EFAULT] REMOTE_RUNNING
```

This occurred because the underlying reservations keys changed which means fenced is running on the other controller. However, the error message shown to user is completely worthless. This resolves that by adding human readable error messages associated with fenced exit codes.