### PR TITLE
NAS-137287 / 26.04 / fix extremely slow start-up times for fenced

### DIFF
--- a/fenced/constants.py
+++ b/fenced/constants.py
@@ -1,0 +1,5 @@
+# WARNING: If you change these, you _MUST_ change
+# the locations in the middleware code-base. These
+# are used in that repo as well.
+PID_FILE = "/var/run/middleware/fenced.pid"
+FENCED_ALERT_FILE = "/data/sentinels/.fenced-alert"

--- a/fenced/disks.py
+++ b/fenced/disks.py
@@ -1,7 +1,7 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor, wait as fut_wait
 
-from middlewared.utils.scsi_generic import inquiry
+from fenced.scsi_generic import inquiry
 
 from libsgio import SCSIErrorException, SCSI_OPCODES, SCSIDevice as SCSI
 from nvme import NvmeDevice as NVME

--- a/fenced/main.py
+++ b/fenced/main.py
@@ -12,9 +12,8 @@ import resource
 from fenced.exceptions import PanicExit, ExcludeDisksError
 from fenced.fence import Fence, ExitCode
 from fenced.logging import setup_logging
+from fenced.constants import PID_FILE, FENCED_ALERT_FILE
 from truenas_api_client import Client
-from middlewared.plugins.failover_.fenced import PID_FILE
-from middlewared.plugins.failover_.scheduled_reboot_alert import FENCED_ALERT_FILE
 
 logger = logging.getLogger(__name__)
 

--- a/fenced/scsi_generic.py
+++ b/fenced/scsi_generic.py
@@ -1,0 +1,129 @@
+import ctypes
+import fcntl
+import os
+
+# SG_IO ioctl command constant
+SG_IO = 0x2285
+
+# SCSI sense buffer size constant
+SG_MAX_SENSE = 32
+
+# Other necessary constants
+SG_DXFER_FROM_DEV = -3
+SG_DXFER_NONE = 0
+SG_FLAG_DIRECT_IO = 1
+SG_INFO_OK = 0
+
+# SCSI Enclosure Services command
+SES_RECEIVE_DIAGNOSTIC = 0x1C
+SES_ENCLOSURE_STATUS_PAGE_CODE = 0x02
+INQUIRY = 0x12
+
+__all__ = ("inquiry",)
+
+
+class sg_io_hdr_v3(ctypes.Structure):
+    _fields_ = [
+        ("interface_id", ctypes.c_int),
+        ("dxfer_direction", ctypes.c_int),
+        ("cmd_len", ctypes.c_ubyte),
+        ("mx_sb_len", ctypes.c_ubyte),
+        ("iovec_count", ctypes.c_ushort),
+        ("dxfer_len", ctypes.c_uint),
+        ("dxferp", ctypes.c_void_p),
+        ("cmdp", ctypes.c_void_p),
+        ("sbp", ctypes.c_void_p),
+        ("timeout", ctypes.c_uint),
+        ("flags", ctypes.c_uint),
+        ("pack_id", ctypes.c_int),
+        ("usr_ptr", ctypes.c_void_p),
+        ("status", ctypes.c_ubyte),
+        ("masked_status", ctypes.c_ubyte),
+        ("msg_status", ctypes.c_ubyte),
+        ("sb_len_wr", ctypes.c_ubyte),
+        ("host_status", ctypes.c_ushort),
+        ("driver_status", ctypes.c_ushort),
+        ("resid", ctypes.c_int),
+        ("duration", ctypes.c_uint),
+        ("info", ctypes.c_uint),
+    ]
+
+
+def get_sgio_hdr_structure(cdb, dxfer_len, timeout=60000):
+    # Create a buffer for the sense data
+    sense_buffer = (ctypes.c_ubyte * SG_MAX_SENSE)()
+    results_buffer = (ctypes.c_ubyte * dxfer_len)()
+
+    hdr = sg_io_hdr_v3()
+    hdr.interface_id = ord("S")
+    hdr.cmd_len = len(cdb)
+    hdr.cmdp = ctypes.cast(cdb, ctypes.c_void_p)
+    hdr.dxfer_direction = SG_DXFER_FROM_DEV
+    hdr.dxfer_len = dxfer_len
+    hdr.dxferp = ctypes.cast(results_buffer, ctypes.c_void_p)
+    hdr.sbp = ctypes.cast(sense_buffer, ctypes.c_void_p)
+    hdr.mx_sb_len = len(sense_buffer)
+    hdr.timeout = timeout
+
+    return hdr, results_buffer, sense_buffer
+
+
+def do_io(device, hdr):
+    fd = os.open(device, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        # Make the ioctl call
+        if fcntl.ioctl(fd, SG_IO, hdr) != 0:
+            raise OSError("SG_IO ioctl failed")
+        elif (hdr.info & SG_INFO_OK) != 0:
+            raise OSError("SG_IO ioctl indicated failure")
+    finally:
+        # Close the device
+        os.close(fd)
+
+
+def inquiry(device):
+    dxfer_len = 0x38
+    cdb = (ctypes.c_ubyte * 6)(INQUIRY, 0x00, 0x00, 0x00, dxfer_len, 0x00)
+    hdr, results_buffer, sense_buffer = get_sgio_hdr_structure(cdb, dxfer_len)
+    do_io(device, hdr)
+
+    # Table 148 in SPC-5
+    t10_vendor_start, t10_vendor_end, t10_final = 8, (15 + 1), ""
+    product_ident_start, product_ident_end, product_ident_final = (
+        t10_vendor_end,
+        (31 + 1),
+        "",
+    )
+    product_rev_start, product_rev_end, product_rev_final = (
+        product_ident_end,
+        (35 + 1),
+        "",
+    )
+    serial_start, serial_end, serial_final = product_rev_end, (55 + 1), ""
+
+    for char in results_buffer[t10_vendor_start:t10_vendor_end]:
+        if (_ascii := chr(char)) in (" ", "\x00"):
+            continue
+        t10_final += _ascii
+
+    for char in results_buffer[product_ident_start:product_ident_end]:
+        if (_ascii := chr(char)) in (" ", "\x00"):
+            continue
+        product_ident_final += _ascii
+
+    for char in results_buffer[product_rev_start:product_rev_end]:
+        if (_ascii := chr(char)) in (" ", "\x00"):
+            continue
+        product_rev_final += _ascii
+
+    for char in results_buffer[serial_start:serial_end]:
+        if (_ascii := chr(char)) in (" ", "\x00"):
+            continue
+        serial_final += _ascii
+
+    return {
+        "vendor": t10_final,
+        "product": product_ident_final,
+        "revision": product_rev_final,
+        "serial": serial_final,
+    }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='fenced',
-    version='0.0.3',
+    version='0.0.4',
     description='TrueNAS SCALE Fencing Daemon',
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Found while testing unrelated issues internally. Starting in GE, start-up times for this program jumped substantially. This is all related to importing junk from middlewared. Middlewared has very involved pydantic API schema models for multiple api versions and the load-times are extreme. Remove all middlewared imports and put them native to fenced. This is of critical importance to ensure failover isn't delayed any longer than what's necessary since this is the first program that is started on a failover event.

NOTE: The "scsi_generic" module was copied verbatim from the middleware repo as to keep risk of regression to a minimum.