### PR TITLE
NAS-138612 / 25.10.1 / fix backupCount variable with logging module (by yocalebo)

### DIFF
--- a/fenced/logging.py
+++ b/fenced/logging.py
@@ -33,7 +33,7 @@ def setup_logging(foreground):
                 'level': 'INFO',
                 'filename': LOG_FILE,
                 'maxBytes': 1000000,  # 1MB size
-                'backupCount': '3',
+                'backupCount': 3,
             },
             'console': {
                 'class': 'logging.StreamHandler',


### PR DESCRIPTION
Testing internally running command `fenced --foreground --force --exclude-disks nvme0n1 --no-panic` caused this error on stderr to be printed
```
[11-19-2025 09:58:21 (INFO) websocket:info():89] - Websocket connected
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/handlers.py", line 74, in emit
    self.doRollover()
  File "/usr/lib/python3.11/logging/handlers.py", line 167, in doRollover
    if self.backupCount > 0:
       ^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'
```

It's a cosmetic error but it breaks logging nonetheless. The fix is very simple.

Original PR: https://github.com/truenas/py-fenced/pull/64
